### PR TITLE
retry: implement exponential backoff for event retry

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -1,7 +1,9 @@
 package events
 
 import (
+	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -46,7 +48,11 @@ retry:
 	if backoff := rs.strategy.Proceed(event); backoff > 0 {
 		select {
 		case <-time.After(backoff):
-			goto retry
+			// TODO(stevvooe): This branch holds up the next try. Before, we
+			// would simply break to the "retry" label and then possibly wait
+			// again. However, this requires all retry strategies to have a
+			// large probability of probing the sync for success, rather than
+			// just backing off and sending the request.
 		case <-rs.closed:
 			return ErrSinkClosed
 		}
@@ -103,9 +109,6 @@ type RetryStrategy interface {
 	Success(event Event)
 }
 
-// TODO(stevvooe): We are using circuit breaker here. May want to provide
-// bounded exponential backoff, as well.
-
 // Breaker implements a circuit breaker retry strategy.
 //
 // The current implementation never drops events.
@@ -157,4 +160,90 @@ func (b *Breaker) Failure(event Event, err error) bool {
 	b.recent++
 	b.last = time.Now().UTC()
 	return false // never drop events.
+}
+
+var (
+	// DefaultExponentialBackoffConfig provides a default configuration for
+	// exponential backoff.
+	DefaultExponentialBackoffConfig = ExponentialBackoffConfig{
+		Base:   time.Second,
+		Factor: time.Second,
+		Max:    20 * time.Second,
+	}
+)
+
+// ExponentialBackoffConfig configures backoff parameters.
+//
+// Note that these parameters operate on the upper bound for choosing a random
+// value. For example, at Base=1s, a random value in [0,1s) will be chosen for
+// the backoff value.
+type ExponentialBackoffConfig struct {
+	// Base is the minimum bound for backing off after failure.
+	Base time.Duration
+
+	// Factor sets the amount of time by which the backoff grows with each
+	// failure.
+	Factor time.Duration
+
+	// Max is the absolute maxiumum bound for a single backoff.
+	Max time.Duration
+}
+
+// ExponentialBackoff implements random backoff with exponentially increasing
+// bounds as the number consecutive failures increase.
+type ExponentialBackoff struct {
+	config   ExponentialBackoffConfig
+	failures uint64 // consecutive failure counter.
+}
+
+// NewExponentialBackoff returns an exponential backoff strategy with the
+// desired config. If config is nil, the default is returned.
+func NewExponentialBackoff(config ExponentialBackoffConfig) *ExponentialBackoff {
+	return &ExponentialBackoff{
+		config: config,
+	}
+}
+
+// Proceed returns the next randomly bound exponential backoff time.
+func (b *ExponentialBackoff) Proceed(event Event) time.Duration {
+	return b.backoff(atomic.LoadUint64(&b.failures))
+}
+
+// Success resets the failures counter.
+func (b *ExponentialBackoff) Success(event Event) {
+	atomic.StoreUint64(&b.failures, 0)
+}
+
+// Failure increments the failure counter.
+func (b *ExponentialBackoff) Failure(event Event, err error) bool {
+	atomic.AddUint64(&b.failures, 1)
+	return false
+}
+
+// backoff calculates the amount of time to wait based on the number of
+// consecutive failures.
+func (b *ExponentialBackoff) backoff(failures uint64) time.Duration {
+	if failures <= 0 {
+		// proceed normally when there are no failures.
+		return 0
+	}
+
+	factor := b.config.Factor
+	if factor <= 0 {
+		factor = DefaultExponentialBackoffConfig.Factor
+	}
+
+	backoff := b.config.Base + factor*time.Duration(1<<(failures-1))
+
+	max := b.config.Max
+	if max <= 0 {
+		max = DefaultExponentialBackoffConfig.Max
+	}
+
+	if backoff > max || backoff < 0 {
+		backoff = max
+	}
+
+	// Choose a uniformly distributed value from [0, backoff).
+	return time.Duration(rand.Int63n(int64(backoff)))
 }


### PR DESCRIPTION
To complement circuit breaker, we now have an exponential backoff retry
strategy. The common increasing bound strategy is implemented.

A small bug was exposed in the implementation that blocked the retry
forever if the strategy did not probe. Now, we simply wait for the retry
and proceed. This may change behavior in the breaker case, but is more
correct.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @diogomonica @aluzzardi @aaronlehmann