### PR TITLE
Change "dropped events" warning to debug-level log message

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -72,10 +72,17 @@ func (eq *Queue) run() {
 		}
 
 		if err := eq.dst.Write(event); err != nil {
+			// TODO(aaronl): Dropping events could be bad depending
+			// on the application. We should have a way of
+			// communicating this condition. However, logging
+			// at a log level above debug may not be appropriate.
+			// Eventually, go-events should not use logrus at all,
+			// and should bubble up conditions like this through
+			// error values.
 			logrus.WithFields(logrus.Fields{
 				"event": event,
 				"sink":  eq.dst,
-			}).WithError(err).Warnf("eventqueue: dropped event")
+			}).WithError(err).Debug("eventqueue: dropped event")
 		}
 	}
 }


### PR DESCRIPTION
In a project where I use go-events, quite a few unit tests and
benchmarks read from a queue until they find what they're looking for,
and then stop reading. There may be more events published to the queue
afterwards, but there's no non-racy way to consume all of them and still
have the test terminate. Thus, these tests and benchmarks tend to log
many `WARN[0004] eventqueue: dropped event` messages.

Change this to the debug log level, so applications and unit tests which
use go-events are not forced to always consume all events to suppress
these messages.