### PR TITLE
queue: Close destination before waiting

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -55,11 +55,14 @@ func (eq *Queue) Close() error {
 		return ErrSinkClosed
 	}
 
+	err := eq.dst.Close()
+
 	// set closed flag
 	eq.closed = true
 	eq.cond.Signal() // signal flushes queue
 	eq.cond.Wait()   // wait for signal from last flush
-	return eq.dst.Close()
+
+	return err
 }
 
 // run is the main goroutine to flush events to the target sink.


### PR DESCRIPTION
The current code tries to flush the queue first and then waits on the
condition variable. This can get stuck if there is a write in progress.
Instead, close the destination first, and then wait afterwards.
