### PR TITLE
[WIP] queue: Return an error when Close is called before the destination is closed

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -98,6 +98,12 @@ func (b *Broadcaster) Close() error {
 	return nil
 }
 
+// Done returns a channel that will always proceed once the broadcaster is
+// closed.
+func (b *Broadcaster) Done() <-chan struct{} {
+	return b.closed
+}
+
 // run is the main broadcast loop, started when the broadcaster is created.
 // Under normal conditions, it waits for events on the event channel. After
 // Close is called, this goroutine will exit.

--- a/channel.go
+++ b/channel.go
@@ -23,7 +23,7 @@ func NewChannel(buffer int) *Channel {
 }
 
 // Done returns a channel that will always proceed once the sink is closed.
-func (ch *Channel) Done() chan struct{} {
+func (ch *Channel) Done() <-chan struct{} {
 	return ch.closed
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -63,6 +63,14 @@ func (ts *testSink) Close() error {
 	return nil
 }
 
+func (ts *testSink) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	if ts.closed {
+		close(ch)
+	}
+	return ch
+}
+
 type delayedSink struct {
 	Sink
 	delay time.Duration

--- a/event.go
+++ b/event.go
@@ -12,4 +12,7 @@ type Sink interface {
 
 	// Close the sink, possibly waiting for pending events to flush.
 	Close() error
+
+	// Done returns a channel that will always proceed once the sink is closed.
+	Done() <-chan struct{}
 }

--- a/retry.go
+++ b/retry.go
@@ -89,6 +89,11 @@ func (rs *RetryingSink) Close() error {
 	return nil
 }
 
+// Done returns a channel that will always proceed once the sink is closed.
+func (rs *RetryingSink) Done() <-chan struct{} {
+	return rs.closed
+}
+
 // RetryStrategy defines a strategy for retrying event sink writes.
 //
 // All methods should be goroutine safe.


### PR DESCRIPTION
Closing the queue before its destination can otherwise cause a deadlock,
because the destination can be stuck in a write.

This causes TestQueue to fail because it expects all events to get written to the sink, but by (correctly) closing the sink before the queue, that ends up not being the case. I'm not sure whether this PR is the right approach.
