### PR TITLE
Avoid recursion in String methods

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -161,17 +161,17 @@ func (b *Broadcaster) run() {
 }
 
 func (b Broadcaster) String() string {
-	// Serialize copy of this broadcaster without the sync.once, to avoid
+	// Serialize copy of this broadcaster without the sync.Once, to avoid
 	// a data race.
 
-	b2 := Broadcaster{
-		sinks:   b.sinks,
-		events:  b.events,
-		adds:    b.adds,
-		removes: b.removes,
+	b2 := map[string]interface{}{
+		"sinks":   b.sinks,
+		"events":  b.events,
+		"adds":    b.adds,
+		"removes": b.removes,
 
-		shutdown: b.shutdown,
-		closed:   b.closed,
+		"shutdown": b.shutdown,
+		"closed":   b.closed,
 	}
 
 	return fmt.Sprint(b2)

--- a/channel.go
+++ b/channel.go
@@ -53,9 +53,9 @@ func (ch *Channel) Close() error {
 func (ch Channel) String() string {
 	// Serialize a copy of the Channel that doesn't contain the sync.Once,
 	// to avoid a data race.
-	ch2 := Channel{
-		C:      ch.C,
-		closed: ch.closed,
+	ch2 := map[string]interface{}{
+		"C":      ch.C,
+		"closed": ch.closed,
 	}
 	return fmt.Sprint(ch2)
 }

--- a/retry.go
+++ b/retry.go
@@ -93,10 +93,10 @@ func (rs *RetryingSink) Close() error {
 func (rs RetryingSink) String() string {
 	// Serialize a copy of the RetryingSink without the sync.Once, to avoid
 	// a data race.
-	rs2 := RetryingSink{
-		sink:     rs.sink,
-		strategy: rs.strategy,
-		closed:   rs.closed,
+	rs2 := map[string]interface{}{
+		"sink":     rs.sink,
+		"strategy": rs.strategy,
+		"closed":   rs.closed,
 	}
 	return fmt.Sprint(rs2)
 }


### PR DESCRIPTION
Let's try this once more...

Use a map instead of the same object type so that the String method
doesn't infinitely recurse.