### PR TITLE
all: fix sync.Once copy

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -160,7 +160,7 @@ func (b *Broadcaster) run() {
 	}
 }
 
-func (b Broadcaster) String() string {
+func (b *Broadcaster) String() string {
 	// Serialize copy of this broadcaster without the sync.Once, to avoid
 	// a data race.
 

--- a/channel.go
+++ b/channel.go
@@ -50,7 +50,7 @@ func (ch *Channel) Close() error {
 	return nil
 }
 
-func (ch Channel) String() string {
+func (ch *Channel) String() string {
 	// Serialize a copy of the Channel that doesn't contain the sync.Once,
 	// to avoid a data race.
 	ch2 := map[string]interface{}{

--- a/retry.go
+++ b/retry.go
@@ -90,7 +90,7 @@ func (rs *RetryingSink) Close() error {
 	return nil
 }
 
-func (rs RetryingSink) String() string {
+func (rs *RetryingSink) String() string {
 	// Serialize a copy of the RetryingSink without the sync.Once, to avoid
 	// a data race.
 	rs2 := map[string]interface{}{


### PR DESCRIPTION
We're doing object copy on String call, but it makes race detector
angry: copy of sync.Once and changing its state at the same time. Also,
it fixes three vet warnings about passing lock by value.

ping @aaronlehmann @stevvooe 