### PR TITLE
update to github.com/sirupsen/logrus v1.0.0

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Broadcaster sends events to multiple, reliable Sinks. The goal of this

--- a/queue.go
+++ b/queue.go
@@ -4,7 +4,7 @@ import (
 	"container/list"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Queue accepts all messages into a queue for asynchronous consumption

--- a/retry.go
+++ b/retry.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // RetryingSink retries the write until success or an ErrSinkClosed is


### PR DESCRIPTION
Signed-off-by: Andrew Pennebaker <apennebaker@datapipe.com>

Fix some dependencies by updating to github.com/sirupsen/logrus (no longer hosted as github.com/Sirupsen/logrus).

Note: `go test` fails on my machine.

```console
$ go test
ERRO[0001] retryingsink: error writing event, retrying   error="error writing event: myevent-1" event=myevent-1
ERRO[0001] retryingsink: error writing event, retrying   error="error writing event: myevent-3" event=myevent-3
ERRO[0001] retryingsink: error writing event, retrying   error="error writing event: myevent-1" event=myevent-1
ERRO[0001] retryingsink: error writing event, retrying   error="error writing event: myevent-2" event=myevent-2
ERRO[0001] retryingsink: error writing event, retrying   error="error writing event: myevent-3" event=myevent-3
...
```