### PR TITLE
Fix channel sink

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -34,10 +34,11 @@ func (ch *Channel) Done() chan struct{} {
 // the listener.
 func (ch *Channel) Write(event Event) error {
 	select {
-	case ch.C <- event:
-		return nil
 	case <-ch.closed:
 		return ErrSinkClosed
+	default:
+		ch.C <- event
+		return nil
 	}
 }
 

--- a/channel.go
+++ b/channel.go
@@ -37,8 +37,12 @@ func (ch *Channel) Write(event Event) error {
 	case <-ch.closed:
 		return ErrSinkClosed
 	default:
-		ch.C <- event
-		return nil
+		select {
+			case <-ch.closed:
+				return ErrSinkClosed
+			case ch.C <- event:
+				return nil
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #29 

It uses the `default` case lower priority to check first if the `Channel` sink is closed.