### PR TITLE
Make queues size-aware

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,4 +7,9 @@ var (
 	// closed. If encountered, the error should be considered terminal and
 	// retries will not be successful.
 	ErrSinkClosed = fmt.Errorf("events: sink closed")
+
+	// ErrQueueFull is returned if a write is issued to a queue that does not
+	// have enough space to store an additional event. If encountered, further
+	// replies may be successful if any of the queue elements was consumed.
+	ErrQueueFull = fmt.Errorf("events: queue full")
 )


### PR DESCRIPTION
The old `NewQueue` factory is left unchanged (infinite queue).
A new `NewSizedQueue` factory is provided with an additional parameter, the size of the `Queue`. Writting when the queue is full returns `ErrQueueFull`.

Based on docker/swarmkit.

Signed-off-by: Adrián Orive <aorive@ikerlan.es>