### PR TITLE
increase event chan size

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -28,7 +28,7 @@ type Broadcaster struct {
 func NewBroadcaster(sinks ...Sink) *Broadcaster {
 	b := Broadcaster{
 		sinks:    sinks,
-		events:   make(chan Event),
+		events:   make(chan Event, 1024),
 		adds:     make(chan configureRequest),
 		removes:  make(chan configureRequest),
 		shutdown: make(chan struct{}),


### PR DESCRIPTION
sometimes I find publish events use several ms  if many events are publishing,I think we can increase the chan size.  PTAL @thaJeztah  @austinvazquez
