### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable automated dependency updates for GitHub Actions workflows.

- Ecosystem: `github-actions`
- Schedule: weekly on Mondays
- Covers all action pins in `.github/workflows/`