### PR TITLE
ci: upgrade golangci-lint to v1.64.8 to fix failing lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
         run: |
           ln -s vendor.mod go.mod
           ln -s vendor.sum go.sum
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
-          version: v1.60.1
+          version: v1.64.8
           skip-cache: true
 
   test:


### PR DESCRIPTION
Upgrade golangci-lint from v1.60.1 to v1.64.8 in the lint CI job.

- v1.60.1 fails on Go export data version 2 produced by the current `oldstable` toolchain:
  `could not load export data: unsupported version: 2`
- v1.64.8 is the latest v1.x release and supports the new export data format
- The `golangci/golangci-lint-action` SHA is unchanged (already at v6.5.2)