### PR TITLE
update golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           ln -s vendor.mod go.mod
           ln -s vendor.sum go.sum
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
           skip-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           ln -s vendor.sum go.sum
       - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
-          version: v1.64.8
+          version: v2.12.2
           skip-cache: true
 
   test:

--- a/channel_test.go
+++ b/channel_test.go
@@ -38,7 +38,7 @@ func TestChannel(t *testing.T) {
 			return
 		}
 
-		sink.Close()
+		_ = sink.Close()
 
 		// now send another bunch of events and ensure we stay closed
 		for i := 1; i <= nevents; i++ {
@@ -76,7 +76,7 @@ loop:
 
 	close(errCh)
 
-	sink.Close()
+	_ = sink.Close()
 	_, ok := <-sink.Done() // test will timeout if this hangs
 	if ok {
 		t.Fatalf("done should be a closed channel")

--- a/common_test.go
+++ b/common_test.go
@@ -109,9 +109,9 @@ func checkClose(t *testing.T, sink Sink) {
 }
 
 func benchmarkSink(b *testing.B, sink Sink) {
-	defer sink.Close()
 	event := "myevent"
 	for i := 0; i < b.N; i++ {
 		_ = sink.Write(event)
 	}
+	_ = sink.Close()
 }


### PR DESCRIPTION
- relates to, closes https://github.com/docker/go-events/pull/45