### PR TITLE
gha: update golang/govulncheck-action to v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,7 @@ jobs:
       - name: Create artifact directory
         run: mkdir -p ${{ env.DESTDIR }}
       - name: Run govulncheck
-        # temporarily using "master" until https://github.com/golang/govulncheck-action/commit/31f7c5463448f83528bd771c2d978d940080c9fd is in a release
-        uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # master
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           go-package: ./...
           check-latest: true


### PR DESCRIPTION
- closes https://github.com/docker/go-events/pull/55