### PR TITLE
deprecate Filter type

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -13,22 +13,27 @@ func (fn MatcherFunc) Match(event Event) bool {
 	return fn(event)
 }
 
-// Filter provides an event sink that sends only events that are accepted by a
-// Matcher. No methods on filter are goroutine safe.
-type Filter struct {
+// Filter is the concrete implementation returned by [NewFilter].
+//
+// Deprecated: Filter should not be constructed directly. Use [NewFilter] instead.
+type Filter = filter
+
+type filter struct {
 	dst     Sink
 	matcher Matcher
 	closed  bool
 }
 
-// NewFilter returns a new filter that will send to events to dst that return
-// true for Matcher.
+// NewFilter returns a new event sink that forwards only events accepted by
+// matcher to dst.
+//
+// The returned Sink's methods are not safe for concurrent use.
 func NewFilter(dst Sink, matcher Matcher) Sink {
-	return &Filter{dst: dst, matcher: matcher}
+	return &filter{dst: dst, matcher: matcher}
 }
 
 // Write an event to the filter.
-func (f *Filter) Write(event Event) error {
+func (f *filter) Write(event Event) error {
 	if f.closed {
 		return ErrSinkClosed
 	}
@@ -41,7 +46,7 @@ func (f *Filter) Write(event Event) error {
 }
 
 // Close the filter and allow no more events to pass through.
-func (f *Filter) Close() error {
+func (f *filter) Close() error {
 	// TODO(stevvooe): Not all sinks should have Close.
 	if f.closed {
 		return nil

--- a/filter_test.go
+++ b/filter_test.go
@@ -5,16 +5,16 @@ import "testing"
 func TestFilter(t *testing.T) {
 	const nevents = 100
 	ts := newTestSink(t, nevents/2)
-	filter := NewFilter(ts, MatcherFunc(func(event Event) bool {
+	f := NewFilter(ts, MatcherFunc(func(event Event) bool {
 		i, ok := event.(int)
 		return ok && i%2 == 0
 	}))
 
 	for i := range nevents {
-		if err := filter.Write(i); err != nil {
+		if err := f.Write(i); err != nil {
 			t.Fatalf("unexpected error writing event: %v", err)
 		}
 	}
 
-	checkClose(t, filter)
+	checkClose(t, f)
 }


### PR DESCRIPTION
- [x] stacked on https://github.com/docker/go-events/pull/73

### deprecate Filter type

Make the filter implementation private and retain Filter as a deprecated
type alias for compatibility.

Direct construction of Filter was never useful because its zero value is not
usable, and NewFilter already returns the Sink interface consumed by callers.
Move the concurrency warning to NewFilter, which is now the documented
construction path.